### PR TITLE
Add ability to include ProcessingEnv vars

### DIFF
--- a/.github/workflows/execute-aws-stepfunctions.yml
+++ b/.github/workflows/execute-aws-stepfunctions.yml
@@ -9,6 +9,11 @@ on:
         required: false
         type: string
         default: ready-to-test
+      processing-env-vars:
+        required: false
+        description: "JSON object with environment variables to pass to the pipeline"
+        type: string
+        default: "{}"
     secrets:
       AWS_ROLE:
         required: true
@@ -66,7 +71,7 @@ jobs:
       id: start_execution
       run: |
         isoDate=$(date -u +"%Y%m%dT%H%M%SZ")
-        executionArn=$(aws stepfunctions start-execution --state-machine-arn $STATE_MACHINE_ARN --name ${STATE_MACHINE_EXECUTION_NAME}_${isoDate} --input "{\"CommitId\": \"${{ github.event.pull_request.head.sha }}\", \"OutputSuffix\": \"pr/${{ github.event.pull_request.head.sha }}/\"}" | jq -r '.executionArn')
+        executionArn=$(aws stepfunctions start-execution --state-machine-arn $STATE_MACHINE_ARN --name ${STATE_MACHINE_EXECUTION_NAME}_${isoDate} --input "{\"CommitId\": \"${{ github.event.pull_request.head.sha }}\", \"OutputSuffix\": \"pr/${{ github.event.pull_request.head.sha }}/\", \"ProcessingEnv\": ${{inputs.processing-env-vars}} }" | jq -r '.executionArn')
         executionUrl="https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/v2/executions/details/$executionArn?tab=definition"
         echo "Step Functions execution started with ARN: $executionArn"
         echo "Execution available at URL: $executionUrl"


### PR DESCRIPTION
Add `processing-env-vars` input to the action with default value `{}`. `processing-env-vars` later included in the `Invoke pipeline` job as part of the `input`.